### PR TITLE
Undefined name: import math for line 179

### DIFF
--- a/envs/gym_mujoco/ant.py
+++ b/envs/gym_mujoco/ant.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import math
 import os
 
 from gym import utils


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/google-research/dads on Python 3.9.0rc2+

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./envs/gym_mujoco/ant.py:178:11: F821 undefined name 'math'
    ori = math.atan2(ori[1], ori[0])
          ^
1     F821 undefined name 'math'
1
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.